### PR TITLE
python: change pip install name to google-cloud-sqlcommenter

### DIFF
--- a/python/sqlcommenter-python/README.md
+++ b/python/sqlcommenter-python/README.md
@@ -6,16 +6,16 @@ Python modules for popular projects that add meta info to your SQL queries as co
  * [SQLAlchemy](#sqlalchemy)
  * [Psycopg2](#psycopg2)
 
-## Install
+## Local Install
 
 ```shell
-pipenv install sqlcommenter
+pip3 install --user .
 ```
 
 If you'd like to record some OpenCensus information as well, just install it:
 
 ```shell
-pipenv install opencensus
+pip3 install opencensus
 ```
 
 ## Usage

--- a/python/sqlcommenter-python/setup.py
+++ b/python/sqlcommenter-python/setup.py
@@ -17,7 +17,7 @@
 from setuptools import find_packages, setup
 
 setup(
-    name='google.cloud.sqlcommenter',
+    name='google-cloud-sqlcommenter',
     version='0.1',
     author='Google Developers',
     author_email='sqlcommenter@googlegroups.com',


### PR DESCRIPTION
Instead of

    google.cloud.sqlcommenter

it'll now be

    google-cloud-sqlcommenter

which seems like the more idiomatic naming convention for Python
software packages, and moreover following google-cloud-storage et al.