### PR TITLE
python: add pkg_resources in the namespace __init__.py

### DIFF
--- a/python/sqlcommenter-python/google/__init__.py
+++ b/python/sqlcommenter-python/google/__init__.py
@@ -13,3 +13,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
For the __init__.py in the main package, this change follows
the advisory at
https://packaging.python.org/guides/packaging-namespace-packages/#pkg-resources-style-namespace-packages

to add the the line

    __import__('pkg_resources').declare_namespace(__name__)

to ONLY the main package's directory i.e. in the same directory
level as setup.py

Fixes #4