### PR TITLE
python: fix broken tests

### DIFF
--- a/python/sqlcommenter-python/google/cloud/sqlcommenter/__init__.py
+++ b/python/sqlcommenter-python/google/cloud/sqlcommenter/__init__.py
@@ -43,6 +43,8 @@ def generate_sql_comment(**meta):
 
 
 def url_quote(s):
+    if not isinstance(s, (str, bytes)):
+        return s
     quoted = url_quote_fn(s)
     # Since SQL uses '%' as a keyword, '%' is a by-product of url quoting
     # e.g. foo,bar --> foo%2Cbar


### PR DESCRIPTION
Tests were previously failing because `psycopg2.__libpq_version__` is an int:
```
======================================================================
ERROR: test_dbapi_threadsafety (tests.psycopg2.tests.Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/aaronabbott/src/tests/psycopg2/tests.py", line 54, in test_dbapi_threadsafety
    with_dbapi_threadsafety=True,
  File "/home/aaronabbott/src/tests/psycopg2/tests.py", line 36, in assertSQL
    self.assertEqual(cursor.execute(None, 'SELECT 1;'), 'worked')
  File "/home/aaronabbott/src/.tox/py36-psycopg2/lib/python3.6/site-packages/google/cloud/sqlcommenter/psycopg2/extension.py", line 70, in execute
    sql += generate_sql_comment(**data)
  File "/home/aaronabbott/src/.tox/py36-psycopg2/lib/python3.6/site-packages/google/cloud/sqlcommenter/__init__.py", line 42, in generate_sql_comment
    ) + '*/'
  File "/home/aaronabbott/src/.tox/py36-psycopg2/lib/python3.6/site-packages/google/cloud/sqlcommenter/__init__.py", line 41, in <genexpr>
    if value is not None
  File "/home/aaronabbott/src/.tox/py36-psycopg2/lib/python3.6/site-packages/google/cloud/sqlcommenter/__init__.py", line 46, in url_quote
    quoted = url_quote_fn(s)
  File "/usr/local/lib/python3.6/urllib/parse.py", line 825, in quote
    return quote_from_bytes(string, safe)
  File "/usr/local/lib/python3.6/urllib/parse.py", line 850, in quote_from_bytes
    raise TypeError("quote_from_bytes() expected bytes")
TypeError: quote_from_bytes() expected bytes

======================================================================
ERROR: test_libpq_version (tests.psycopg2.tests.Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/aaronabbott/src/tests/psycopg2/tests.py", line 71, in test_libpq_version
    "SELECT 1; /*libpq_version={}*/".format(url_quote(psycopg2.__libpq_version__)),
  File "/home/aaronabbott/src/.tox/py36-psycopg2/lib/python3.6/site-packages/google/cloud/sqlcommenter/__init__.py", line 46, in url_quote
    quoted = url_quote_fn(s)
  File "/usr/local/lib/python3.6/urllib/parse.py", line 825, in quote
    return quote_from_bytes(string, safe)
  File "/usr/local/lib/python3.6/urllib/parse.py", line 850, in quote_from_bytes
    raise TypeError("quote_from_bytes() expected bytes")
TypeError: quote_from_bytes() expected bytes
```

This skips calling the quoting function when we aren't dealing with string/bytes and tests now pass.