### PR TITLE
python: Add OpenTelemetry support

### DIFF
--- a/python/sqlcommenter-python/.gitignore
+++ b/python/sqlcommenter-python/.gitignore
@@ -4,3 +4,4 @@ build/
 *.sw[op]
 .tox/
 MANIFEST
+venv/

--- a/python/sqlcommenter-python/README.md
+++ b/python/sqlcommenter-python/README.md
@@ -12,10 +12,17 @@ Python modules for popular projects that add meta info to your SQL queries as co
 pip3 install --user google-cloud-sqlcommenter
 ```
 
-If you'd like to record some OpenCensus information as well, just install it:
+If you'd like to record the OpenCensus trace context as well, just install it:
 
 ```shell
-pip3 install opencensus
+pip3 install google-cloud-sqlcommenter[opencensus]
+```
+
+If you'd like to record the OpenTelemetry trace context as well (Python 3+ only),
+just install it:
+
+```shell
+pip3 install google-cloud-sqlcommenter[opentelemetry]
 ```
 
 ## Usage
@@ -38,11 +45,13 @@ which when viewed say on Postgresql logs, produces
 ('Wassup?', '2019-05-28T18:54:50.767481+00:00'::timestamptz) RETURNING
 "polls_question"."id" /*controller='index',framework='django%3A2.2.1',route='%5Epolls/%24'*/
 ```
-If you want the opencensus attributes included, you must set the
-``SQLCOMMENTER_WITH_OPENCENSUS`` setting to ``True`` and include
-``'opencensus.ext.django.middleware.OpencensusMiddleware'`` before
-``'google.cloud.sqlcommenter.django.middleware.SqlCommenter',`` in your ``MIDDLEWARE``
-setting.
+If you want the OpenCensus attributes included, you must set the
+``SQLCOMMENTER_WITH_OPENCENSUS`` setting to ``True``.
+
+If you want the OpenTelemetry attributes included, you must set the
+``SQLCOMMENTER_WITH_OPENTELEMETRY`` setting to ``True``.
+
+You cannot use OpenTelemetry and OpenCensus together, as they use the same attributes.
 
 ### SQLAlchemy
 
@@ -53,7 +62,13 @@ import sqlalchemy
 from google.cloud.sqlcommenter.sqlalchemy.executor import BeforeExecuteFactory
 
 engine = sqlalchemy.create_engine(...)
-listener = BeforeExecuteFactory(with_db_driver=True, with_db_framework=True, with_opencensus=True)
+listener = BeforeExecuteFactory(
+    with_db_driver=True,
+    with_db_framework=True,
+    # you may use one of opencensus or opentelemetry
+    with_opencensus=True,
+    with_opentelemetry=True,
+)
 sqlalchemy.event.listen(engine, 'before_cursor_execute', listener, retval=True)
 engine.execute(...) # comment will be added before execution
 ```
@@ -75,8 +90,15 @@ import psycopg2
 from google.cloud.sqlcommenter.psycopg2.extension import CommenterCursorFactory
 
 cursor_factory = CommenterCursorFactory(
-    with_db_driver=True, with_dbapi_level=True, with_dbapi_threadsafety=True,
-    with_driver_paramstyle=True, with_libpq_version=True, with_opencensus=True)
+    with_db_driver=True,
+    with_dbapi_level=True,
+    with_dbapi_threadsafety=True,
+    with_driver_paramstyle=True,
+    with_libpq_version=True,
+    # you may use one of opencensus or opentelemetry
+    with_opencensus=True,
+    with_opentelemetry=True,
+)
 conn = psycopg2.connect(..., cursor_factory=cursor_factory)
 cursor = conn.cursor()
 cursor.execute(...) # comment will be added before execution
@@ -95,23 +117,32 @@ tracestate='congo%%3Dt61rcWkgMzE%%2Crojo%%3D00f067aa0ba902b7'*/
 
 With Django, each option translates to a Django setting by uppercasing it and prepending `SQLCOMMENTER_`. For example, `with_framework` is controlled by the django setting `SQLCOMMENTER_WITH_FRAMEWORK`.
 
-| Options | Included by default? | Django | SQLAlchemy | psycopg2 | Notes |
-| ------- | :------------------: | ------ | ---------- | -------- | :---: |
-| `with_framework` | :heavy_check_mark: | [Django version](https://docs.djangoproject.com/en/stable/releases/)  | [Flask version](http://flask.pocoo.org/) | [Flask version](http://flask.pocoo.org/) |
-| `with_controller` | :heavy_check_mark: | [Django view](https://docs.djangoproject.com/en/stable/ref/urlresolvers/#django.urls.ResolverMatch.view_name)  | [Flask endpoint](http://flask.pocoo.org/docs/1.0/api/#flask.Flask.endpoint) | [Flask endpoint](http://flask.pocoo.org/docs/1.0/api/#flask.Flask.endpoint) |
-| `with_route` | :heavy_check_mark: | [Django route](https://docs.djangoproject.com/en/stable/ref/urlresolvers/#django.urls.ResolverMatch.route)  | [Flask route](http://flask.pocoo.org/docs/1.0/api/#flask.Flask.route) | [Flask route](http://flask.pocoo.org/docs/1.0/api/#flask.Flask.route) |
-| `with_app_name ` | | [Django app name](https://docs.djangoproject.com/en/stable/ref/urlresolvers/#django.urls.ResolverMatch.app_name) | | |
-| `with_opencensus` | | [W3C TraceContext.Traceparent](https://www.w3.org/TR/trace-context/#traceparent-field), [W3C TraceContext.Tracestate](https://www.w3.org/TR/trace-context/#tracestate-field) | [W3C TraceContext.Traceparent](https://www.w3.org/TR/trace-context/#traceparent-field), [W3C TraceContext.Tracestate](https://www.w3.org/TR/trace-context/#tracestate-field) | [W3C TraceContext.Traceparent](https://www.w3.org/TR/trace-context/#traceparent-field), [W3C TraceContext.Tracestate](https://www.w3.org/TR/trace-context/#tracestate-field) | [[1]](#1-opencensus)
-| `with_db_driver` | | [Django DB engine](https://docs.djangoproject.com/en/stable/ref/settings/#engine) | [SQLAlchemy DB driver](https://docs.sqlalchemy.org/en/13/core/engines.html#database-urls) | [psycopg2 version](http://initd.org/psycopg/docs/) |
-| `with_db_framework` | | | [SQLAlchemy version](https://www.sqlalchemy.org/) | |
-| `with_dbapi_threadsafety` | | | | [psycopg2 thread safety](http://initd.org/psycopg/docs/module.html#psycopg2.threadsafety) |
-| `with_dbapi_level` | | | | [psycopg2 api level](http://initd.org/psycopg/docs/module.html#psycopg2.apilevel) |
-| `with_libpq_version` | | | | [psycopg2 libpq version](http://initd.org/psycopg/docs/module.html#psycopg2.__libpq_version__) |
-| `with_driver_paramstyle` | | | | [psycopg2 parameter style](http://initd.org/psycopg/docs/module.html#psycopg2.paramstyle) |
+| Options                   | Included by default? | Django                                                                                                                                                                       | SQLAlchemy                                                                                                                                                                   | psycopg2                                                                                                                                                                     |                          Notes                          |
+| ------------------------- | :------------------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-----------------------------------------------------: |
+| `with_framework`          |  :heavy_check_mark:  | [Django version](https://docs.djangoproject.com/en/stable/releases/)                                                                                                         | [Flask version](http://flask.pocoo.org/)                                                                                                                                     | [Flask version](http://flask.pocoo.org/)                                                                                                                                     |
+| `with_controller`         |  :heavy_check_mark:  | [Django view](https://docs.djangoproject.com/en/stable/ref/urlresolvers/#django.urls.ResolverMatch.view_name)                                                                | [Flask endpoint](http://flask.pocoo.org/docs/1.0/api/#flask.Flask.endpoint)                                                                                                  | [Flask endpoint](http://flask.pocoo.org/docs/1.0/api/#flask.Flask.endpoint)                                                                                                  |
+| `with_route`              |  :heavy_check_mark:  | [Django route](https://docs.djangoproject.com/en/stable/ref/urlresolvers/#django.urls.ResolverMatch.route)                                                                   | [Flask route](http://flask.pocoo.org/docs/1.0/api/#flask.Flask.route)                                                                                                        | [Flask route](http://flask.pocoo.org/docs/1.0/api/#flask.Flask.route)                                                                                                        |
+| `with_app_name `          |                      | [Django app name](https://docs.djangoproject.com/en/stable/ref/urlresolvers/#django.urls.ResolverMatch.app_name)                                                             |                                                                                                                                                                              |                                                                                                                                                                              |
+| `with_opencensus`         |                      | [W3C TraceContext.Traceparent](https://www.w3.org/TR/trace-context/#traceparent-field), [W3C TraceContext.Tracestate](https://www.w3.org/TR/trace-context/#tracestate-field) | [W3C TraceContext.Traceparent](https://www.w3.org/TR/trace-context/#traceparent-field), [W3C TraceContext.Tracestate](https://www.w3.org/TR/trace-context/#tracestate-field) | [W3C TraceContext.Traceparent](https://www.w3.org/TR/trace-context/#traceparent-field), [W3C TraceContext.Tracestate](https://www.w3.org/TR/trace-context/#tracestate-field) |  [[1]](#1-opencensus)[[3]](#3-traceparent/tracestate)   |
+| `with_opentelemetry`      |                      | [W3C TraceContext.Traceparent](https://www.w3.org/TR/trace-context/#traceparent-field), [W3C TraceContext.Tracestate](https://www.w3.org/TR/trace-context/#tracestate-field) | [W3C TraceContext.Traceparent](https://www.w3.org/TR/trace-context/#traceparent-field), [W3C TraceContext.Tracestate](https://www.w3.org/TR/trace-context/#tracestate-field) | [W3C TraceContext.Traceparent](https://www.w3.org/TR/trace-context/#traceparent-field), [W3C TraceContext.Tracestate](https://www.w3.org/TR/trace-context/#tracestate-field) | [[2]](#2-opentelemetry)[[3]](#3-traceparent/tracestate) |
+| `with_db_driver`          |                      | [Django DB engine](https://docs.djangoproject.com/en/stable/ref/settings/#engine)                                                                                            | [SQLAlchemy DB driver](https://docs.sqlalchemy.org/en/13/core/engines.html#database-urls)                                                                                    | [psycopg2 version](http://initd.org/psycopg/docs/)                                                                                                                           |
+| `with_db_framework`       |                      |                                                                                                                                                                              | [SQLAlchemy version](https://www.sqlalchemy.org/)                                                                                                                            |                                                                                                                                                                              |
+| `with_dbapi_threadsafety` |                      |                                                                                                                                                                              |                                                                                                                                                                              | [psycopg2 thread safety](http://initd.org/psycopg/docs/module.html#psycopg2.threadsafety)                                                                                    |
+| `with_dbapi_level`        |                      |                                                                                                                                                                              |                                                                                                                                                                              | [psycopg2 api level](http://initd.org/psycopg/docs/module.html#psycopg2.apilevel)                                                                                            |
+| `with_libpq_version`      |                      |                                                                                                                                                                              |                                                                                                                                                                              | [psycopg2 libpq version](http://initd.org/psycopg/docs/module.html#psycopg2.__libpq_version__)                                                                               |
+| `with_driver_paramstyle`  |                      |                                                                                                                                                                              |                                                                                                                                                                              | [psycopg2 parameter style](http://initd.org/psycopg/docs/module.html#psycopg2.paramstyle)                                                                                    |
 
 #### [1] `opencensus`
 
-For `opencensus` to work correctly, note that:
+For `opencensus` to work correctly, note that [OpenCensus for
+Python](https://github.com/census-instrumentation/opencensus-python) must be
+installed in the python environment.
 
-* [OpenCensus for Python](https://github.com/census-instrumentation/opencensus-python) must be installed in the python environment.
-* Because the W3C TraceContext's `traceparent` and `tracestate` are quite ephemeral per request, including these attributes can have a negative impact on query caching.
+#### [2] `opentelemetry`
+
+For `opentelemetry` to work correctly, note that [OpenTelemetry for
+Python](https://github.com/open-telemetry/opentelemetry-python) must be
+installed in the python environment.
+
+#### [3] `traceparent/tracestate`
+Because the W3C TraceContext's `traceparent` and `tracestate` are quite ephemeral per request, including these attributes can have a negative impact on query caching.

--- a/python/sqlcommenter-python/google/cloud/sqlcommenter/opentelemetry.py
+++ b/python/sqlcommenter-python/google/cloud/sqlcommenter/opentelemetry.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+try:
+    from opentelemetry.trace.propagation.tracecontext import (
+        TraceContextTextMapPropagator,
+    )
+
+    propagator = TraceContextTextMapPropagator()
+except ImportError:
+    propagator = None
+
+
+def _setter(headers, key, value):
+    headers[key] = value
+
+
+def get_opentelemetry_values():
+    """
+    Return the OpenTelemetry Trace and Span IDs if Span ID is set in the
+    OpenTelemetry execution context.
+    """
+    if propagator:
+        # Insert the W3C TraceContext generated
+        headers = {}
+        propagator.inject(_setter, headers)
+        return headers
+    else:
+        raise ImportError("OpenTelemetry is not installed.")

--- a/python/sqlcommenter-python/google/cloud/sqlcommenter/psycopg2/extension.py
+++ b/python/sqlcommenter-python/google/cloud/sqlcommenter/psycopg2/extension.py
@@ -23,8 +23,8 @@ from google.cloud.sqlcommenter.flask import get_flask_info
 from google.cloud.sqlcommenter.opencensus import get_opencensus_values
 from google.cloud.sqlcommenter.opentelemetry import get_opentelemetry_values
 
-
 logger = logging.getLogger(__name__)
+
 
 # This integration extends psycopg2.extensions.cursor
 # by implementing a custom execute method.

--- a/python/sqlcommenter-python/google/cloud/sqlcommenter/psycopg2/extension.py
+++ b/python/sqlcommenter-python/google/cloud/sqlcommenter/psycopg2/extension.py
@@ -14,12 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 import psycopg2
 import psycopg2.extensions
 from google.cloud.sqlcommenter import generate_sql_comment
 from google.cloud.sqlcommenter.flask import get_flask_info
 from google.cloud.sqlcommenter.opencensus import get_opencensus_values
+from google.cloud.sqlcommenter.opentelemetry import get_opentelemetry_values
 
+
+logger = logging.getLogger(__name__)
 
 # This integration extends psycopg2.extensions.cursor
 # by implementing a custom execute method.
@@ -29,8 +34,9 @@ from google.cloud.sqlcommenter.opencensus import get_opencensus_values
 # by instead setting with_opencensus=True
 def CommenterCursorFactory(
         with_framework=True, with_controller=True, with_route=True,
-        with_opencensus=False, with_db_driver=False, with_dbapi_threadsafety=False,
-        with_dbapi_level=False, with_libpq_version=False, with_driver_paramstyle=False):
+        with_opencensus=False, with_opentelemetry=False, with_db_driver=False,
+        with_dbapi_threadsafety=False, with_dbapi_level=False,
+        with_libpq_version=False, with_driver_paramstyle=False):
 
     attributes = {
         'framework': with_framework,
@@ -64,8 +70,15 @@ def CommenterCursorFactory(
             # Filter down to just the requested attributes.
             data = {k: v for k, v in data.items() if attributes.get(k)}
 
+            if with_opencensus and with_opentelemetry:
+                logger.warning(
+                    "with_opencensus and with_opentelemetry were enabled. "
+                    "Only use one to avoid unexpected behavior"
+                )
             if with_opencensus:
                 data.update(get_opencensus_values())
+            if with_opentelemetry:
+                data.update(get_opentelemetry_values())
 
             sql += generate_sql_comment(**data)
 

--- a/python/sqlcommenter-python/google/cloud/sqlcommenter/sqlalchemy/executor.py
+++ b/python/sqlcommenter-python/google/cloud/sqlcommenter/sqlalchemy/executor.py
@@ -17,6 +17,7 @@
 # This integration implements the before_cursor_execute hook factory as per:
 #   https://kite.com/python/docs/sqlalchemy.events.ConnectionEvents.before_execute
 from __future__ import absolute_import
+
 import logging
 
 import sqlalchemy
@@ -25,8 +26,8 @@ from google.cloud.sqlcommenter.flask import get_flask_info
 from google.cloud.sqlcommenter.opencensus import get_opencensus_values
 from google.cloud.sqlcommenter.opentelemetry import get_opentelemetry_values
 
-
 logger = logging.getLogger(__name__)
+
 
 def BeforeExecuteFactory(
         with_framework=True, with_controller=True, with_route=True,

--- a/python/sqlcommenter-python/setup.py
+++ b/python/sqlcommenter-python/setup.py
@@ -37,6 +37,8 @@ setup(
         'flask': ['flask'],
         'psycopg2': ['psycopg2'],
         'sqlalchemy': ['sqlalchemy'],
+        'opencensus': ['opencensus'],
+        'opentelemetry': ["opentelemetry-api; python_version >= '3'"],
     },
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/python/sqlcommenter-python/setup.py
+++ b/python/sqlcommenter-python/setup.py
@@ -18,9 +18,11 @@ import os
 
 from setuptools import find_packages, setup
 
+
 def read_file(filename):
     with open(os.path.join(os.path.dirname(__file__), filename)) as file:
         return file.read()
+
 
 setup(
     name='google-cloud-sqlcommenter',

--- a/python/sqlcommenter-python/tests/compat.py
+++ b/python/sqlcommenter-python/tests/compat.py
@@ -30,5 +30,5 @@ def skipIfPy2(testcase):
         sys.version_info.major == 2, "Feature only support in python3+"
     )(testcase)
 
-__all__ = ["mock"]
 
+__all__ = ["mock"]

--- a/python/sqlcommenter-python/tests/compat.py
+++ b/python/sqlcommenter-python/tests/compat.py
@@ -15,9 +15,20 @@
 # limitations under the License.
 
 """Python 2 compatibility shims."""
+
+import sys
+import unittest
+
 try:
     from unittest import mock
 except ImportError:  # Python 2
     import mock
 
-__all__ = ['mock']
+
+def skipIfPy2(testcase):
+    return unittest.skipIf(
+        sys.version_info.major == 2, "Feature only support in python3+"
+    )(testcase)
+
+__all__ = ["mock"]
+

--- a/python/sqlcommenter-python/tests/generic/test_opentelemetry.py
+++ b/python/sqlcommenter-python/tests/generic/test_opentelemetry.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+
+import six
+from google.cloud.sqlcommenter.opentelemetry import get_opentelemetry_values
+
+from ..compat import mock, skipIfPy2
+from ..opentelemetry_mock import mock_opentelemetry_context
+
+
+@skipIfPy2
+class OpenTelemetryTests(TestCase):
+    def test_not_installed(self):
+        with mock.patch("google.cloud.sqlcommenter.opentelemetry.propagator", new=None):
+            with six.assertRaisesRegex(
+                self, ImportError, "OpenTelemetry is not installed"
+            ):
+                get_opentelemetry_values()
+
+    def test_no_values(self):
+        self.assertEqual(get_opentelemetry_values(), {})
+
+    def test_trace_parent_and_tracestate(self):
+        with mock_opentelemetry_context():
+            self.assertEqual(
+                get_opentelemetry_values(),
+                {
+                    "traceparent": "00-000000000000000000000000deadbeef-000000000000beef-00",
+                    "tracestate": "some_key=some_value",
+                },
+            )
+
+    def test_trace_flags(self):
+        from opentelemetry import trace
+        with mock_opentelemetry_context(trace_flags=trace.TraceFlags.SAMPLED):
+            self.assertEqual(
+                get_opentelemetry_values(),
+                {
+                    "traceparent": "00-000000000000000000000000deadbeef-000000000000beef-01",
+                    "tracestate": "some_key=some_value",
+                },
+            )
+
+    def test_empty_trace_state(self):
+        with mock_opentelemetry_context(trace_state={}):
+            self.assertEqual(
+                get_opentelemetry_values(),
+                {
+                    "traceparent": "00-000000000000000000000000deadbeef-000000000000beef-00",
+                },
+            )

--- a/python/sqlcommenter-python/tests/opentelemetry_mock.py
+++ b/python/sqlcommenter-python/tests/opentelemetry_mock.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import contextmanager
+
+try:
+    from opentelemetry import context, trace
+
+    @contextmanager
+    def mock_opentelemetry_context(
+        trace_id=0xDEADBEEF, span_id=0xBEEF, trace_flags=None, trace_state=None
+    ):
+        if not context:
+            yield
+            return
+
+        span_context = trace.SpanContext(
+            trace_id=trace_id,
+            span_id=span_id,
+            is_remote=True,
+            trace_flags=trace_flags,
+            trace_state=trace.TraceState(
+                **(
+                    trace_state
+                    if trace_state is not None
+                    else {"some_key": "some_value"}
+                )
+            ),
+        )
+        ctx = trace.set_span_in_context(trace.DefaultSpan(span_context))
+        token = context.attach(ctx)
+        yield
+        context.detach(token)
+
+
+except ImportError:
+    # python2.7 tests will not have opentelemetry installed
+    @contextmanager
+    def mock_opentelemetry_context(*args, **kwargs):
+        yield

--- a/python/sqlcommenter-python/tests/opentelemetry_mock.py
+++ b/python/sqlcommenter-python/tests/opentelemetry_mock.py
@@ -23,10 +23,6 @@ try:
     def mock_opentelemetry_context(
         trace_id=0xDEADBEEF, span_id=0xBEEF, trace_flags=None, trace_state=None
     ):
-        if not context:
-            yield
-            return
-
         span_context = trace.SpanContext(
             trace_id=trace_id,
             span_id=span_id,
@@ -34,16 +30,17 @@ try:
             trace_flags=trace_flags,
             trace_state=trace.TraceState(
                 **(
-                    trace_state
-                    if trace_state is not None
+                    trace_state if trace_state is not None
                     else {"some_key": "some_value"}
                 )
             ),
         )
         ctx = trace.set_span_in_context(trace.DefaultSpan(span_context))
         token = context.attach(ctx)
-        yield
-        context.detach(token)
+        try:
+            yield
+        finally:
+            context.detach(token)
 
 
 except ImportError:

--- a/python/sqlcommenter-python/tests/psycopg2/tests.py
+++ b/python/sqlcommenter-python/tests/psycopg2/tests.py
@@ -88,7 +88,7 @@ class Tests(Psycopg2TestCase):
                 "tracestate='some_key%%3Dsome_value'*/",
                 with_opentelemetry=True,
             )
-    
+
     def test_both_opentelemetry_and_opencensus_warn(self):
         with mock.patch(
             "google.cloud.sqlcommenter.psycopg2.extension.logger"
@@ -100,6 +100,7 @@ class Tests(Psycopg2TestCase):
                 with_opencensus=True,
             )
             self.assertEqual(len(logger_mock.warning.mock_calls), 1)
+
 
 class FlaskTests(Psycopg2TestCase):
     flask_info = {

--- a/python/sqlcommenter-python/tests/sqlalchemy/tests.py
+++ b/python/sqlcommenter-python/tests/sqlalchemy/tests.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 from unittest import TestCase
-from unittest.case import skip, skipIf
 
 import sqlalchemy
 from google.cloud.sqlcommenter.sqlalchemy.executor import BeforeExecuteFactory
@@ -127,4 +126,3 @@ class FlaskTests(SQLAlchemyTestCase):
             "SELECT 1; /*controller='c',framework='flask'*/",
             with_route=False,
         )
-

--- a/python/sqlcommenter-python/tox.ini
+++ b/python/sqlcommenter-python/tox.ini
@@ -28,7 +28,7 @@ commands =
 skip_install = True
 deps =
     flake8
-    isort
+    isort < 5
 commands =
     flake8
     isort --recursive --check-only --diff

--- a/python/sqlcommenter-python/tox.ini
+++ b/python/sqlcommenter-python/tox.ini
@@ -15,6 +15,7 @@ deps =
     flask: flask
     flask: pytest
     opencensus
+    !py27: opentelemetry-api
     psycopg2: forbiddenfruit
     psycopg2: psycopg2
     sqlalchemy: sqlalchemy


### PR DESCRIPTION
Add support for OpenTelemetry trace context in python.

- OpenTelemetry only supports python3+, so there is some complication there around the test code.
- If the user tries to use OpenCenus AND OpenTelemetry, we log a warning since they write to the same sql comment
- Passing tox tests run locally for python 2.7, 3.5, 3.6, and 3.7
- Tested psycopg2 manually with a script writing to cloud monitoring. See next PR https://github.com/google/sqlcommenter/pull/39