### PR TITLE
Add django version information

### DIFF
--- a/python/sqlcommenter-python/README.md
+++ b/python/sqlcommenter-python/README.md
@@ -29,6 +29,8 @@ pip3 install google-cloud-sqlcommenter[opentelemetry]
 
 ### Django
 
+> Django version 2.0 or higher is required
+
 Add the provided Django middleware to your Django project's settings. All queries executed within the standard request→response cycle will have the SQL comment prepended to them.
 
 ```python


### PR DESCRIPTION
At least Django version 2.0 is required as sqlcommenter makes use of DatabseWrapper.execute_wrapper.
This implicitly means that python3.4 or higher is required too as that's what Django 2.0 supports