### PR TITLE
Opentelemetry dependencies loaded conditionally

### DIFF
--- a/nodejs/sqlcommenter-nodejs/packages/sqlcommenter-knex/package.json
+++ b/nodejs/sqlcommenter-nodejs/packages/sqlcommenter-knex/package.json
@@ -23,7 +23,8 @@
     "sinon-chai": "^3.5.0"
   },
   "peerDependencies": {
-    "@opentelemetry/core": "^0.12.0"
+    "@opentelemetry/core": "^0.12.0",
+    "knex": "*"
   },
   "dependencies": {
     "@opencensus/nodejs": "^0.0.22",

--- a/nodejs/sqlcommenter-nodejs/packages/sqlcommenter-knex/package.json
+++ b/nodejs/sqlcommenter-nodejs/packages/sqlcommenter-knex/package.json
@@ -23,9 +23,11 @@
     "sinon-chai": "^3.5.0"
   },
   "peerDependencies": {
-    "@opencensus/nodejs": "^0.0.22",
-    "@opencensus/propagation-tracecontext": "^0.0.22",
     "@opentelemetry/core": "^0.12.0"
+  },
+  "dependencies": {
+    "@opencensus/nodejs": "^0.0.22",
+    "@opencensus/propagation-tracecontext": "^0.0.22"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/nodejs/sqlcommenter-nodejs/packages/sqlcommenter-knex/provider/index.js
+++ b/nodejs/sqlcommenter-nodejs/packages/sqlcommenter-knex/provider/index.js
@@ -13,18 +13,15 @@
 // limitations under the License.
 
 const OpenCensus = require('./opencensus');
-const OpenTelemetry = require('./opentelemetry');
-
-const providers = {
-    'opentelemetry': OpenTelemetry,
-    'opencensus': OpenCensus,
-}
 
 exports.attachComments = function attachComments(providerName, comments) {
     // Verify we have a comments object to modify
     if (!comments || typeof comments !== 'object') return;
 
     // Lookup the provider by name, or use the default.
-    let provider = providers[String(providerName).toLowerCase()] || OpenCensus;
+    let provider = OpenCensus;
+    if(String(providerName).toLowerCase() === 'opentelemetry') {
+        provider = require('./opentelemetry')
+    }
     provider.addW3CTraceContext(comments);
 }


### PR DESCRIPTION
## Why
I wanted to use the `sqlcommenter` in our Express app to get annotated queries in GCP Cloud SQL Query Insights but found there were couple peer dependencies that I was missing. Some of them were critical for `sqlcommenter` to run (namely `@opencensus/nodejs` and `@opencensus/propagation-tracecontext`), while `@opentelemetry/core` is really optional and used only if one decides to use `opentelemetry` as the `provider`.

I have created very simple Express + Knex application to demonstrate the problem: https://github.com/jstastny/sqlcommenter-demo

I hope this improves the experience of adding this library to a project. I understand that this will add the `@opencensus` dependencies even for users that decide for `opentelemetry`. In case this is a problem, this PR can be reworked and both `opentelemetry` and `opencensus` be made optional, but we should improve documentation to guide users to install the according peer dependencies depending on what provider they are about to use.

## Changes
- the code in `provider` was changed so that the `@opentelemetry` library is required only if it is used
- `@opencensus/nodejs` and `@opencensus/propagation-tracecontext` moved from `peerDependencies` to `dependencies`
- `knex` added to `peerDependencies`

Addresses https://github.com/google/sqlcommenter/issues/23