### PR TITLE
Updating log4j-slf4j library from 2.11.2 to 2.16.0

### DIFF
--- a/java/sqlcommenter-java/build.gradle
+++ b/java/sqlcommenter-java/build.gradle
@@ -58,7 +58,10 @@ dependencies {
     implementation "io.opentelemetry:opentelemetry-sdk:${opentelemetryVersion}"
 
     // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-web
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '2.1.5.RELEASE'
+    compile (group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '2.1.5.RELEASE') {
+        exclude group: 'org.apache.logging.log4j', module: 'log4j-to-slf4j'
+    }
+    compile 'org.apache.logging.log4j:log4j-to-slf4j:2.16.0'
 
     compile 'org.hibernate:hibernate-core:5.4.3.Final'
 

--- a/java/sqlcommenter-java/src/main/java/com/google/cloud/sqlcommenter/schibernate/SCHibernate.java
+++ b/java/sqlcommenter-java/src/main/java/com/google/cloud/sqlcommenter/schibernate/SCHibernate.java
@@ -19,7 +19,8 @@ import com.google.cloud.sqlcommenter.threadlocalstorage.State;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
 
 public class SCHibernate implements StatementInspector {
-  private static final io.opencensus.trace.Tracer openCensusTracer = io.opencensus.trace.Tracing.getTracer();
+  private static final io.opencensus.trace.Tracer openCensusTracer =
+      io.opencensus.trace.Tracing.getTracer();
 
   /**
    * inspect augments SQL with statements about the current code setup if any. It tries to check if


### PR DESCRIPTION
Updating the log4j api to mitigate the security vulnerability.