### PR TITLE
docs(sqlcommenter_rails/README): update marginalia fork to modulitos

### DIFF
--- a/ruby/sqlcommenter-ruby/sqlcommenter_rails/README.md
+++ b/ruby/sqlcommenter-ruby/sqlcommenter_rails/README.md
@@ -14,7 +14,7 @@ Powered by [marginalia] and [marginalia-opencensus].
 Currently, this gem is not released on rubygems.
 But can be installed from source.
 
-The gem requires functionality provided by an [open PR](https://github.com/basecamp/marginalia/pull/89) to [marginalia](https://github.com/basecamp/marginalia). Install the PR by cloning [glebm's fork of marginalia](https://github.com/glebm/marginalia) one directory above this folder.
+The gem requires functionality provided by an [open PR](https://github.com/basecamp/marginalia/pull/130) to [marginalia](https://github.com/basecamp/marginalia). Install the PR by cloning [modulitos's fork of marginalia](https://github.com/modulitos/marginalia) one directory above this folder.
 
 ```bash
 git clone https://github.com/glebm/marginalia.git ../marginalia


### PR DESCRIPTION
This PR updates the `sqlcommeter_rails` readme so that it references the `modulitos` fork instead of the `glebm` fork. The `modulitos` fork is basically the same, except that it rebases the latest changes from the `master` branch of the `marginalia` repo, so that we'll have support for Rails6.

For reference, here's the original commit where this README was originally updated:
https://github.com/google/sqlcommenter/commit/70d62f0b71dc28056aaac26537fdf98aeaecd17b

Here's the PR to merge the `modulitos` fork into the `master` branch of `marginalia`:
https://github.com/basecamp/marginalia/pull/130

I am working with the `marginalia` maintainers to get that PR merged in. When I do, I will update this README so that we can remove the need for forking `marginalia` :)