### PR TITLE
docs(sqlcommenter_rails/README): update marginalia fork to modulitos

### DIFF
--- a/ruby/sqlcommenter-ruby/sqlcommenter_rails/README.md
+++ b/ruby/sqlcommenter-ruby/sqlcommenter_rails/README.md
@@ -14,10 +14,10 @@ Powered by [marginalia] and [marginalia-opencensus].
 Currently, this gem is not released on rubygems.
 But can be installed from source.
 
-The gem requires functionality provided by an [open PR](https://github.com/basecamp/marginalia/pull/89) to [marginalia](https://github.com/basecamp/marginalia). Install the PR by cloning [glebm's fork of marginalia](https://github.com/glebm/marginalia) one directory above this folder.
+The gem requires functionality provided by an [open PR](https://github.com/basecamp/marginalia/pull/130) to [marginalia](https://github.com/basecamp/marginalia). Install the PR by cloning [modulitos's fork of marginalia](https://github.com/modulitos/marginalia) one directory above this folder.
 
 ```bash
-git clone https://github.com/glebm/marginalia.git ../marginalia
+git clone https://github.com/modulitos/marginalia.git ../marginalia
 ```
 
 Add the following lines to your application's Gemfile:

--- a/ruby/sqlcommenter-ruby/sqlcommenter_rails_demo/README.md
+++ b/ruby/sqlcommenter-ruby/sqlcommenter_rails_demo/README.md
@@ -9,10 +9,10 @@ This is a demo [Rails API] application to demonstrate [sqlcommenter_rails] integ
 
 Install [Ruby v2.6.3](https://www.ruby-lang.org/en/news/2019/04/17/ruby-2-6-3-released/) if you don't already have it installed.
 
-This demo requires functionality provided by an [open PR](https://github.com/basecamp/marginalia/pull/89) to [marginalia](https://github.com/basecamp/marginalia). Install the PR by cloning [glebm's fork of marginalia](https://github.com/glebm/marginalia) one directory above this demo. Starting from the root directory of this demo:
+This demo requires functionality provided by an [open PR](https://github.com/basecamp/marginalia/pull/130) to [marginalia](https://github.com/basecamp/marginalia). Install the PR by cloning [modulitos's fork of marginalia](https://github.com/modulitos/marginalia) one directory above this demo. Starting from the root directory of this demo:
 
 ```bash
-git clone https://github.com/glebm/marginalia.git ../marginalia
+git clone https://github.com/modulitos/marginalia.git ../marginalia
 git -C ../marginalia checkout formatting
 ```
 


### PR DESCRIPTION
This PR updates the `sqlcommeter_rails` readme so that it references the `modulitos` fork instead of the `glebm` fork. The `modulitos` fork makes the same changes as the `glebm` fork, except that it rebases the latest changes from the `master` branch of the `marginalia` repo, so that we'll have support for Rails 6.

For reference, here's the original commit where this README was originally updated:
https://github.com/google/sqlcommenter/commit/70d62f0b71dc28056aaac26537fdf98aeaecd17b

Here's the PR to merge the `modulitos` fork into the `master` branch of `marginalia`:
https://github.com/basecamp/marginalia/pull/130

I am working with the `marginalia` maintainers to get that PR merged in. When I do, I will update this README so that we can remove this extra step of using a `marginalia` fork :)

Note: 
Sorry about the [duplicate PRs that I created earlier](https://github.com/google/sqlcommenter/pull/98) - I was having trouble getting the Google CLA checks to pass.