### PR TITLE
Fix SQLCommenter comment addition before end of SQL statement delimiter

### DIFF
--- a/python/sqlcommenter-python/google/cloud/sqlcommenter/psycopg2/extension.py
+++ b/python/sqlcommenter-python/google/cloud/sqlcommenter/psycopg2/extension.py
@@ -80,7 +80,12 @@ def CommenterCursorFactory(
             if with_opentelemetry:
                 data.update(get_opentelemetry_values())
 
-            sql += generate_sql_comment(**data)
+            if len(data) != 0:
+                sql = sql.rstrip()
+                if sql[-1] == ';':
+                    sql = sql[:-1] + generate_sql_comment(**data) + ';'
+                else:
+                    sql = sql + generate_sql_comment(**data)
 
             return psycopg2.extensions.cursor.execute(self, sql, args)
 

--- a/python/sqlcommenter-python/tests/psycopg2/tests.py
+++ b/python/sqlcommenter-python/tests/psycopg2/tests.py
@@ -45,47 +45,47 @@ class Tests(Psycopg2TestCase):
 
     def test_db_driver(self):
         self.assertSQL(
-            "SELECT 1; /*db_driver='psycopg2%%3A{}'*/".format(url_quote(psycopg2.__version__)),
+            "SELECT 1 /*db_driver='psycopg2%%3A{}'*/;".format(url_quote(psycopg2.__version__)),
             with_db_driver=True,
         )
 
     def test_dbapi_threadsafety(self):
         self.assertSQL(
-            "SELECT 1; /*dbapi_threadsafety={}*/".format(psycopg2.threadsafety),
+            "SELECT 1 /*dbapi_threadsafety={}*/;".format(psycopg2.threadsafety),
             with_dbapi_threadsafety=True,
         )
 
     def test_driver_paramstyle(self):
         self.assertSQL(
-            "SELECT 1; /*driver_paramstyle='{}'*/".format(psycopg2.paramstyle),
+            "SELECT 1 /*driver_paramstyle='{}'*/;".format(psycopg2.paramstyle),
             with_driver_paramstyle=True,
         )
 
     def test_dbapi_level(self):
         self.assertSQL(
-            "SELECT 1; /*dbapi_level='{}'*/".format(url_quote(psycopg2.apilevel)),
+            "SELECT 1 /*dbapi_level='{}'*/;".format(url_quote(psycopg2.apilevel)),
             with_dbapi_level=True,
         )
 
     def test_libpq_version(self):
         self.assertSQL(
-            "SELECT 1; /*libpq_version={}*/".format(url_quote(psycopg2.__libpq_version__)),
+            "SELECT 1 /*libpq_version={}*/;".format(url_quote(psycopg2.__libpq_version__)),
             with_libpq_version=True,
         )
 
     def test_opencensus(self):
         with mock_opencensus_tracer():
             self.assertSQL(
-                "SELECT 1; /*traceparent='00-trace%%20id-span%%20id-00',"
-                "tracestate='congo%%3Dt61rcWkgMzE%%2Crojo%%3D00f067aa0ba902b7'*/",
+                "SELECT 1 /*traceparent='00-trace%%20id-span%%20id-00',"
+                "tracestate='congo%%3Dt61rcWkgMzE%%2Crojo%%3D00f067aa0ba902b7'*/;",
                 with_opencensus=True,
             )
 
     def test_opentelemetry(self):
         with mock_opentelemetry_context():
             self.assertSQL(
-                "SELECT 1; /*traceparent='00-000000000000000000000000deadbeef-000000000000beef-00',"
-                "tracestate='some_key%%3Dsome_value'*/",
+                "SELECT 1 /*traceparent='00-000000000000000000000000deadbeef-000000000000beef-00',"
+                "tracestate='some_key%%3Dsome_value'*/;",
                 with_opentelemetry=True,
             )
 
@@ -94,8 +94,8 @@ class Tests(Psycopg2TestCase):
             "google.cloud.sqlcommenter.psycopg2.extension.logger"
         ) as logger_mock, mock_opencensus_tracer(), mock_opentelemetry_context():
             self.assertSQL(
-                "SELECT 1; /*traceparent='00-000000000000000000000000deadbeef-000000000000beef-00',"
-                "tracestate='some_key%%3Dsome_value'*/",
+                "SELECT 1 /*traceparent='00-000000000000000000000000deadbeef-000000000000beef-00',"
+                "tracestate='some_key%%3Dsome_value'*/;",
                 with_opentelemetry=True,
                 with_opencensus=True,
             )
@@ -112,26 +112,26 @@ class FlaskTests(Psycopg2TestCase):
     @mock.patch('google.cloud.sqlcommenter.psycopg2.extension.get_flask_info', return_value=flask_info)
     def test_all_data(self, get_info):
         self.assertSQL(
-            "SELECT 1; /*controller='c',framework='flask',route='/'*/",
+            "SELECT 1 /*controller='c',framework='flask',route='/'*/;",
         )
 
     @mock.patch('google.cloud.sqlcommenter.psycopg2.extension.get_flask_info', return_value=flask_info)
     def test_framework_disabled(self, get_info):
         self.assertSQL(
-            "SELECT 1; /*controller='c',route='/'*/",
+            "SELECT 1 /*controller='c',route='/'*/;",
             with_framework=False,
         )
 
     @mock.patch('google.cloud.sqlcommenter.psycopg2.extension.get_flask_info', return_value=flask_info)
     def test_controller_disabled(self, get_info):
         self.assertSQL(
-            "SELECT 1; /*framework='flask',route='/'*/",
+            "SELECT 1 /*framework='flask',route='/'*/;",
             with_controller=False,
         )
 
     @mock.patch('google.cloud.sqlcommenter.psycopg2.extension.get_flask_info', return_value=flask_info)
     def test_route_disabled(self, get_info):
         self.assertSQL(
-            "SELECT 1; /*controller='c',framework='flask'*/",
+            "SELECT 1 /*controller='c',framework='flask'*/;",
             with_route=False,
         )


### PR DESCRIPTION
At present we are appending comments to the SQL Statements after semi-colon `;`.

For Example:
```
SELECT 1; /*db_driver='driver'*/
```

This comment would not be part of the SQL Statement as `;` acts as a delimiter and hence won't associate with the comment.

This PR fixes that by:
1. removing spaces from end of the line.
2. if the last character is `;`, insert the comment before `;`