### PR TITLE
fix: use new comment formatter for sqlcommenter-rails

### DIFF
--- a/ruby/sqlcommenter-ruby/sqlcommenter_rails/lib/sqlcommenter_rails/marginalia_components.rb
+++ b/ruby/sqlcommenter-ruby/sqlcommenter_rails/lib/sqlcommenter_rails/marginalia_components.rb
@@ -34,7 +34,6 @@ module Marginalia
   end
 end
 
-Marginalia::Comment.key_value_separator = '='
-Marginalia::Comment.quote_values = :single
+Marginalia::Comment.update_formatter!(:sqlcommenter)
 Marginalia::Comment.components += %i[framework db_driver route]
 Marginalia::Comment.components.sort!


### PR DESCRIPTION
Following the [changes](https://github.com/modulitos/marginalia/commit/0c55ab893fe6e2d0887d5478ff4ec52eaad25fae) to how comment formatter is configured in [modulitos's fork of marginalia](https://github.com/modulitos/marginalia), these changes in marginalia_components.rb are also required in order for the [demo](https://github.com/google/sqlcommenter/tree/master/ruby/sqlcommenter-ruby/sqlcommenter_rails_demo) and any app using sqlcommenter-rails to work.