### PR TITLE
Refactor: Remove/Replace unnecessary implementations in PHP (Laravel)

### DIFF
--- a/php/sqlcommenter-php/packages/sqlcommenter-laravel/src/Database/Connection.php
+++ b/php/sqlcommenter-php/packages/sqlcommenter-laravel/src/Database/Connection.php
@@ -26,119 +26,51 @@ use Google\GoogleSqlCommenterLaravel\Utils;
 class Connection extends BaseConnection
 {
     /**
-     * Run a select statement and return a single result.
-     *
-     * @param  string  $query
-     * @param  array  $bindings
-     * @param  bool  $useReadPdo
-     * @return mixed
+     * @inheritDoc
      */
-    public function selectOne($query, $bindings = [], $useReadPdo = true)
+    protected function run($query, $bindings, \Closure $callback)
     {
-        $query = $this->getSqlComments($query);
-        $records = parent::select($query, $bindings, $useReadPdo);
-
-        if (count($records) > 0) {
-            return $records;
-        }
-        return null;
+        return parent::run(
+            $this->appendSqlComments($query),
+            $bindings,
+            $callback
+        );
     }
 
-    /**
-     * Run a select statement against the database.
-     *
-     * @param  string  $query
-     * @param  array  $bindings
-     * @param  bool  $useReadPdo
-     * @return array
-     */
-    public function select($query, $bindings = [], $useReadPdo = true)
+    private function appendSqlComments(string $query): string
     {
-        $query = $this->getSqlComments($query);
-        $records = parent::select($query, $bindings, $useReadPdo);
-        return $records;
-    }
-
-    /**
-     * Run an insert statement against the database.
-     *
-     * @param  string  $query
-     * @param  array  $bindings
-     * @return bool
-     */
-    public function insert($query, $bindings = [])
-    {
-        $query = $this->getSqlComments($query);
-        $records = parent::insert($query, $bindings);
-
-        return $records;
-    }
-
-    /**
-     * Run an update statement against the database.
-     *
-     * @param  string  $query
-     * @param  array  $bindings
-     * @return int
-     */
-    public function update($query, $bindings = [])
-    {
-        $query = $this->getSqlComments($query);
-      
-        return $this->affectingStatement($query, $bindings);
-    }
-
-    /**
-     * Run a delete statement against the database.
-     *
-     * @param  string  $query
-     * @param  array  $bindings
-     * @return int
-     */
-    public function delete($query, $bindings = [])
-    {
-
-        $query = $this->getSqlComments($query);
-
-        return $this->affectingStatement($query, $bindings);
-    }
-
-    private function getSqlComments($query)
-    {
-        $configurationKey = 'google_sqlcommenter.include.';
-        $comment = [];
+        static $configurationKey = 'google_sqlcommenter.include';
+        $comments = [];
         $action = null;
 
-        if (!empty(app('request')->route())) {
-            $action = app('request')->route()->getAction();
+        if (!empty(request()->route())) {
+            $action = request()->route()->getAction();
         }
-        if (config($configurationKey . 'framework', true)) {
-            $comment['framework'] = "laravel-" . app()->version();
+        if (config("{$configurationKey}.framework", true)) {
+            $comments['framework'] = "laravel-" . app()->version();
         }
-        if (config($configurationKey . 'controller', true) and !empty($action['controller'])) {
-            $comment['controller'] = explode("@", class_basename($action['controller']))[0];
+        if (config("{$configurationKey}.controller", true) && !empty($action['controller'])) {
+            $comments['controller'] = explode("@", class_basename($action['controller']))[0];
         }
-        if (config($configurationKey . 'action', true) and !empty($action and $action['controller'] and str_contains($action['controller'], '@'))) {
-            $comment['action'] = explode("@", class_basename($action['controller']))[1];
+        if (config("{$configurationKey}.action", true) && !empty($action and $action['controller'] && str_contains($action['controller'], '@'))) {
+            $comments['action'] = explode("@", class_basename($action['controller']))[1];
         }
-        if (config($configurationKey . 'route', true)) {
-            $comment['route'] = request()->getRequestUri();
+        if (config("{$configurationKey}.route", true)) {
+            $comments['route'] = request()->getRequestUri();
         }
-        if (config($configurationKey . 'db_driver', true)) {
+        if (config("{$configurationKey}.db_driver", true)) {
             $connection = config('database.default');
-            $comment['db_driver'] = config("database.connections.{$connection}.driver");
+            $comments['db_driver'] = config("database.connections.{$connection}.driver");
         }
-        if (config($configurationKey . 'opentelemetry', true)) {
+        if (config("{$configurationKey}.opentelemetry", true)) {
             $carrier = Opentelemetry::getOpentelemetryValues();
-            $comment = array_merge($comment, $carrier);
+            $comments = $comments + $carrier;
         }
 
-        $query=trim($query);
+        $query = trim($query);
+        $hasSemicolon = $query[-1] === ';';
+        $query = rtrim($query, ';');
 
-        if ($query[-1] == ';'){
-            return rtrim($query ,";"). Utils::formatComments(array_filter(($comment))). ';';
-        }
-        return $query . Utils::formatComments(array_filter(($comment)));
-
+        return $query . Utils::formatComments(array_filter($comments)) . ($hasSemicolon ? ';' : '');
     }
 }

--- a/php/sqlcommenter-php/packages/sqlcommenter-laravel/src/Utils.php
+++ b/php/sqlcommenter-php/packages/sqlcommenter-laravel/src/Utils.php
@@ -28,13 +28,13 @@ class Utils
         return "/*" . implode(
             ',',
             array_map(
-                fn (string $value, string $key) => Utils::customEncode($key) . "='" . Utils::customEncode($value) . "'", $comments,
+                static fn (string $value, string $key) => Utils::customUrlEncode($key) . "='" . Utils::customUrlEncode($value) . "'", $comments,
                 array_keys($comments)
             ),
         ) . "*/";
     }
 
-    private static function customEncode(string $input): string
+    private static function customUrlEncode(string $input): string
     {
         $encodedString = urlencode($input);
 

--- a/php/sqlcommenter-php/packages/sqlcommenter-laravel/src/Utils.php
+++ b/php/sqlcommenter-php/packages/sqlcommenter-laravel/src/Utils.php
@@ -19,31 +19,29 @@ namespace Google\GoogleSqlCommenterLaravel;
 
 class Utils
 {
-    public static function formatComments($comment)
+    public static function formatComments(array $comments): string
     {
-        if (empty($comment)) {
+        if (empty($comments)) {
             return "";
         }
-        $lastElement = array_key_last($comment);
-        $sql_comment = "/*";
-        foreach ($comment as $key => $value) {
-            if ($key == $lastElement) {
-                $sql_comment .= Utils::customUrlEncode($key) . "=" . "'" . Utils::customUrlEncode($value) . "'*/";
-            } else {
-                $sql_comment .= Utils::customUrlEncode($key) . "=" . "'" . Utils::customUrlEncode($value) . "',";
-            }
-        }
-        return $sql_comment;
+
+        return "/*" . implode(
+            ',',
+            array_map(
+                fn (string $value, string $key) => Utils::customEncode($key) . "='" . Utils::customEncode($value) . "'", $comments,
+                array_keys($comments)
+            ),
+        ) . "*/";
     }
 
-    private static function customUrlEncode($input)
+    private static function customEncode(string $input): string
     {
         $encodedString = urlencode($input);
 
-        # Since SQL uses '%' as a keyword, '%' is a by-product of url quoting
-        # e.g. foo,bar --> foo%2Cbar
-        # thus in our quoting, we need to escape it too to finally give
-        #      foo,bar --> foo%%2Cbar
+        // Since SQL uses '%' as a keyword, '%' is a by-product of url quoting
+        // e.g. foo,bar --> foo%2Cbar
+        // thus in our quoting, we need to escape it too to finally give
+        //      foo,bar --> foo%%2Cbar
 
         return str_replace("%", "%%", $encodedString);
     }

--- a/php/sqlcommenter-php/packages/sqlcommenter-laravel/tests/Unit/UtilsTest.php
+++ b/php/sqlcommenter-php/packages/sqlcommenter-laravel/tests/Unit/UtilsTest.php
@@ -22,26 +22,26 @@ final class UtilsTest extends TestCase
 {
     public function testFormatCommentsWithKeys(): void
     {
-        $this->assertEquals("/*key1='value1',key2='value2'*/", Utils::formatComments(array("key1" => "value1", "key2" => "value2")));
+        $this->assertEquals("/*key1='value1',key2='value2'*/", Utils::formatComments(["key1" => "value1", "key2" => "value2"]));
     }
 
     public function testFormatCommentsWithoutKeys(): void
     {
-        $this->assertEquals("", Utils::formatComments(array()));
+        $this->assertEquals("", Utils::formatComments([]));
     }
 
     public function testFormatCommentsWithSpecialCharKeys(): void
     {
-        $this->assertEquals("/*key1='value1%%40',key2='value2'*/", Utils::formatComments(array("key1" => "value1@", "key2" => "value2")));
+        $this->assertEquals("/*key1='value1%%40',key2='value2'*/", Utils::formatComments(["key1" => "value1@", "key2" => "value2"]));
     }
 
     public function testFormatCommentsWithPlaceholder(): void
     {
-        $this->assertEquals("/*key1='value1%%3F',key2='value2'*/", Utils::formatComments(array("key1" => "value1?", "key2" => "value2")));
+        $this->assertEquals("/*key1='value1%%3F',key2='value2'*/", Utils::formatComments(["key1" => "value1?", "key2" => "value2"]));
     }
 
     public function testFormatCommentsWithNamedPlaceholder(): void
     {
-        $this->assertEquals("/*key1='%%3Anamed',key2='value2'*/", Utils::formatComments(array("key1" => ":named", "key2" => "value2")));
+        $this->assertEquals("/*key1='%%3Anamed',key2='value2'*/", Utils::formatComments(["key1" => ":named", "key2" => "value2"]));
     }
 }

--- a/php/sqlcommenter-php/packages/sqlcommenter-laravel/tests/Unit/UtilsTest.php
+++ b/php/sqlcommenter-php/packages/sqlcommenter-laravel/tests/Unit/UtilsTest.php
@@ -24,12 +24,24 @@ final class UtilsTest extends TestCase
     {
         $this->assertEquals("/*key1='value1',key2='value2'*/", Utils::formatComments(array("key1" => "value1", "key2" => "value2")));
     }
+
     public function testFormatCommentsWithoutKeys(): void
     {
         $this->assertEquals("", Utils::formatComments(array()));
     }
+
     public function testFormatCommentsWithSpecialCharKeys(): void
     {
         $this->assertEquals("/*key1='value1%%40',key2='value2'*/", Utils::formatComments(array("key1" => "value1@", "key2" => "value2")));
+    }
+
+    public function testFormatCommentsWithPlaceholder(): void
+    {
+        $this->assertEquals("/*key1='value1%%3F',key2='value2'*/", Utils::formatComments(array("key1" => "value1?", "key2" => "value2")));
+    }
+
+    public function testFormatCommentsWithNamedPlaceholder(): void
+    {
+        $this->assertEquals("/*key1='%%3Anamed',key2='value2'*/", Utils::formatComments(array("key1" => ":named", "key2" => "value2")));
     }
 }


### PR DESCRIPTION
I remove/replace unnecessary implementations in PHP (Laravel):
- You don't need to wrap functions for example `selectOne`, `select`, `affectingStatement`. The laravel always calls the `run` function in the Connection class.
- `&&` is better than the `and` operator because it is different calculating order in an expression.
- Added tests because placeholders (`?`) and named placeholders (`:named`) are not ensured in the test.
- In using `#` as a comment-out, it is confusing for the attribution feature in PHP, therefore `//` is better than `#`.