### PR TITLE
Ruby on Rails documentation updates

### DIFF
--- a/ruby/sqlcommenter-ruby/README.md
+++ b/ruby/sqlcommenter-ruby/README.md
@@ -1,1 +1,19 @@
-# sqlcommenter-ruby
+# SQLCommenter in Ruby
+
+## SQLCommenter support in Rails
+
+
+Support for [SQLCommenter](https://google.github.io/sqlcommenter/) in [Ruby on Rails](https://rubyonrails.org/) varies, depending on your versions of Rails.
+
+If you are on Rails version:
+
+ - **7.1 and above:** SQLCommenter is supported by default. Enable [query_log_tags](https://guides.rubyonrails.org/configuring.html#config-active-record-query-log-tags-enabled), and SQLCommenter formatting will be [enabled by default](https://edgeguides.rubyonrails.org/configuring.html#config-active-record-query-log-tags-format).
+ - **7.0:** Enable [query_log_tags](https://guides.rubyonrails.org/configuring.html#config-active-record-query-log-tags-enabled) and install the [PlanetScale SQLCommenter gem](https://github.com/planetscale/activerecord-sql_commenter#installation) for SQLCommenter support.
+ - **Below 7.0:** Refer to the [sqlcommenter_rails gem](https://github.com/google/sqlcommenter/tree/master/ruby/sqlcommenter-ruby/sqlcommenter_rails) in this directory for adding SQLCommenter support. Note that this requires additional work because you will have to install a fork of the [marginalia](https://github.com/basecamp/marginalia/) gem, which has since been consolidated into Rails 7.0 and up.
+
+## Tracing support in Rails
+
+Tracing support has been implemented in the [marginalia-opencensus gem]: https://github.com/google/sqlcommenter/tree/master/ruby/sqlcommenter-ruby/marginalia-opencensus. Note that this only works for Rails versions below 7.0, before the [marginalia](https://github.com/basecamp/marginalia/) gem was consolidated into Rails.
+
+Re-purposing that gem for Rails versions >=7.0 should only require minor modifications (contributions are welcome!).
+

--- a/ruby/sqlcommenter-ruby/sqlcommenter_rails/README.md
+++ b/ruby/sqlcommenter-ruby/sqlcommenter_rails/README.md
@@ -1,5 +1,7 @@
 # sqlcommenter_rails
 
+**If you are on Rails version 7.0 and up, refer to the [sqlcommenter-ruby README] instead**
+
 [sqlcommenter] for [Ruby on Rails].
 
 Powered by [marginalia] and [marginalia-opencensus].
@@ -8,6 +10,7 @@ Powered by [marginalia] and [marginalia-opencensus].
 [Ruby on Rails]: https://rubyonrails.org/
 [marginalia]: https://github.com/basecamp/marginalia/
 [marginalia-opencensus]: https://github.com/google/sqlcommenter/tree/master/ruby/sqlcommenter-ruby/marginalia-opencensus
+[sqlcommenter-ruby README]: https://github.com/google/sqlcommenter/tree/master/ruby/sqlcommenter-ruby
 
 ## Installation
 

--- a/ruby/sqlcommenter-ruby/sqlcommenter_rails_demo/README.md
+++ b/ruby/sqlcommenter-ruby/sqlcommenter_rails_demo/README.md
@@ -1,9 +1,12 @@
 # sqlcommenter_rails demo
 
+**If you are on Rails version 7.0 and up, refer to the [sqlcommenter-ruby README] instead**
+
 This is a demo [Rails API] application to demonstrate [sqlcommenter_rails] integration.
 
 [Rails API]: https://guides.rubyonrails.org/api_app.html
 [sqlcommenter_rails]: https://github.com/google/sqlcommenter/ruby/sqlcommenter-ruby/sqlcommenter_rails
+[sqlcommenter-ruby README]: https://github.com/google/sqlcommenter/tree/master/ruby/sqlcommenter-ruby
 
 ## Setup
 


### PR DESCRIPTION
This PR updates the Ruby docs to leverage the support Rails has recently provided for SQLCommenter. This will facilitate adoption of SQLCommenter for folks who aren't familiar with how SQLCommenter support has changed across Rails versions.

Note that the current docs are not compatible with Rails versions 7.0 and up. This PR makes the following changes to bring them up to date:
1.  For Rails >=7.1, include docs about how SQLCommenter is now fully supported as the default formatter
     - Support was added in [this PR](https://github.com/rails/rails/pull/45081), and it will be the default formatter as well (added in [this PR](https://github.com/rails/rails/pull/46180)).
2. For Rails 7.0, include docs on the [PlanetScale SQLCommenter gem](https://github.com/planetscale/activerecord-sql_commenter#installation) which is a workaround that provides SQLCommenter support for Rails 7.0
      - The Marginalia library was re-implemented natively in Rails version 7.0 (in [this PR](https://github.com/rails/rails/pull/42240)), so the current documentation that leverages a Marginalia fork will not work.

Corresponding PR in the OpenTelemetry repo: https://github.com/open-telemetry/opentelemetry-sqlcommenter/pull/35