### PR TITLE
database type in driver tag

### DIFF
--- a/go/database/sql/go-sql.go
+++ b/go/database/sql/go-sql.go
@@ -25,12 +25,13 @@ import (
 
 type DB struct {
 	*sql.DB
-	options core.CommenterOptions
+	driverName string
+	options    core.CommenterOptions
 }
 
 func Open(driverName string, dataSourceName string, options core.CommenterOptions) (*DB, error) {
 	db, err := sql.Open(driverName, dataSourceName)
-	return &DB{DB: db, options: options}, err
+	return &DB{DB: db, driverName: driverName, options: options}, err
 }
 
 // ***** Query Functions *****
@@ -79,7 +80,7 @@ func (db *DB) withComment(ctx context.Context, query string) string {
 	// `driver` information should not be coming from framework.
 	// So, explicitly adding that here.
 	if db.options.EnableDBDriver {
-		commentsMap[core.Driver] = "database/sql"
+		commentsMap[core.Driver] = fmt.Sprintf("database/sql:%s", db.driverName)
 	}
 
 	if db.options.EnableFramework && (ctx.Value(core.Framework) != nil) {

--- a/go/database/sql/go-sql_test.go
+++ b/go/database/sql/go-sql_test.go
@@ -32,7 +32,7 @@ func TestDisabled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MockSQL failed with unexpected error: %s", err)
 	}
-	db := DB{DB: mockDB, options: core.CommenterOptions{}}
+	db := DB{DB: mockDB, driverName: "mocksql", options: core.CommenterOptions{}}
 	query := "SELECT 2"
 	if got, want := db.withComment(context.Background(), query), query; got != want {
 		t.Errorf("db.withComment(context.Background(), %q) = %q, want = %q", query, got, want)
@@ -45,7 +45,7 @@ func TestHTTP_Net(t *testing.T) {
 		t.Fatalf("MockSQL failed with unexpected error: %s", err)
 	}
 
-	db := DB{DB: mockDB, options: core.CommenterOptions{EnableDBDriver: true, EnableRoute: true, EnableFramework: true}}
+	db := DB{DB: mockDB, driverName: "mocksql", options: core.CommenterOptions{EnableDBDriver: true, EnableRoute: true, EnableFramework: true}}
 	r, err := http.NewRequest("GET", "hello/1", nil)
 	if err != nil {
 		t.Errorf("http.NewRequest('GET', 'hello/1', nil) returned unexpected error: %v", err)
@@ -53,7 +53,7 @@ func TestHTTP_Net(t *testing.T) {
 
 	ctx := core.ContextInject(r.Context(), httpnet.NewHTTPRequestExtractor(r, nil))
 	got := db.withComment(ctx, "Select 1")
-	want := "Select 1/*driver=database%2Fsql,framework=net%2Fhttp,route=hello%2F1*/"
+	want := "Select 1/*driver=database%2Fsql%3Amocksql,framework=net%2Fhttp,route=hello%2F1*/"
 	if got != want {
 		t.Errorf("db.withComment(ctx, 'Select 1') got %q, wanted %q", got, want)
 	}
@@ -65,9 +65,9 @@ func TestQueryWithSemicolon(t *testing.T) {
 		t.Fatalf("MockSQL failed with unexpected error: %s", err)
 	}
 
-	db := DB{DB: mockDB, options: core.CommenterOptions{EnableDBDriver: true}}
+	db := DB{DB: mockDB, driverName: "mocksql", options: core.CommenterOptions{EnableDBDriver: true}}
 	got := db.withComment(context.Background(), "Select 1;")
-	want := "Select 1/*driver=database%2Fsql*/;"
+	want := "Select 1/*driver=database%2Fsql%3Amocksql*/;"
 	if got != want {
 		t.Errorf("db.withComment(context.Background(), 'Select 1;') got %q, wanted %q", got, want)
 	}
@@ -79,7 +79,7 @@ func TestOtelIntegration(t *testing.T) {
 		t.Fatalf("MockSQL failed with unexpected error: %s", err)
 	}
 
-	db := DB{DB: mockDB, options: core.CommenterOptions{EnableTraceparent: true}}
+	db := DB{DB: mockDB, driverName: "mocksql", options: core.CommenterOptions{EnableTraceparent: true}}
 	exp, _ := stdouttrace.New(stdouttrace.WithPrettyPrint())
 	bsp := sdktrace.NewSimpleSpanProcessor(exp) // You should use batch span processor in prod
 	tp := sdktrace.NewTracerProvider(


### PR DESCRIPTION
this PR adds the database-type in the `driver` tag in this form - `database/sql:{driverName}`. PR includes changes to tests