### PR TITLE
Add support for drivers with ConnBeginTx interface

### DIFF
--- a/go/core/core.go
+++ b/go/core/core.go
@@ -52,8 +52,14 @@ type StaticTags struct {
 }
 
 type CommenterOptions struct {
+	Driver DriverOptions
 	Config CommenterConfig
 	Tags   StaticTags
+}
+
+type DriverOptions struct {
+	// Setting this to true means your underlying driver supports the ConnBeginTx interface
+	WithBeginTX bool
 }
 
 func encodeURL(k string) string {
@@ -71,7 +77,7 @@ func ConvertMapToComment(tags map[string]string) string {
 	var sb strings.Builder
 	i, sz := 0, len(tags)
 
-	//sort by keys
+	// sort by keys
 	sortedKeys := make([]string, 0, len(tags))
 	for k := range tags {
 		sortedKeys = append(sortedKeys, k)

--- a/go/database/sql/connection.go
+++ b/go/database/sql/connection.go
@@ -31,6 +31,19 @@ type sqlCommenterConn struct {
 	options core.CommenterOptions
 }
 
+type sqlCommenterConnWithTx struct {
+	sqlCommenterConn
+}
+
+func newConn(conn driver.Conn, options core.CommenterOptions) driver.Conn {
+	commenterConn := newSQLCommenterConn(conn, options)
+	if options.Driver.WithBeginTX {
+		return &sqlCommenterConnWithTx{*commenterConn}
+	}
+
+	return commenterConn
+}
+
 func newSQLCommenterConn(conn driver.Conn, options core.CommenterOptions) *sqlCommenterConn {
 	return &sqlCommenterConn{
 		Conn:    conn,
@@ -87,6 +100,15 @@ func (s *sqlCommenterConn) PrepareContext(ctx context.Context, query string) (st
 
 func (s *sqlCommenterConn) Raw() driver.Conn {
 	return s.Conn
+}
+
+func (s *sqlCommenterConnWithTx) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	begintxer, ok := s.Conn.(driver.ConnBeginTx)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+
+	return begintxer.BeginTx(ctx, opts)
 }
 
 // ***** Commenter Functions *****

--- a/go/database/sql/gosql.go
+++ b/go/database/sql/gosql.go
@@ -43,7 +43,7 @@ func (d *sqlCommenterDriver) Open(name string) (driver.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newSQLCommenterConn(rawConn, d.options), nil
+	return newConn(rawConn, d.options), nil
 }
 
 func (d *sqlCommenterDriver) OpenConnector(name string) (driver.Connector, error) {
@@ -73,7 +73,7 @@ func (c *sqlCommenterConnector) Connect(ctx context.Context) (connection driver.
 	if err != nil {
 		return nil, err
 	}
-	return newSQLCommenterConn(connection, c.options), nil
+	return newConn(connection, c.options), nil
 }
 
 func (c *sqlCommenterConnector) Driver() driver.Driver {


### PR DESCRIPTION
Some drivers implement the `ConnBeginTx` interface, without it its not possible to specify Isolation mode for queries in Postgres. So I've implemented it.
If you like this implementation let me know and I will add a test.