### PR TITLE
Fix SQLCommenter database/sql test

### DIFF
--- a/go/database/sql/connection_test.go
+++ b/go/database/sql/connection_test.go
@@ -41,7 +41,7 @@ func TestWithComment_NoContext(t *testing.T) {
 				Config: core.CommenterConfig{EnableDBDriver: true},
 			},
 			query:     "SELECT 1;",
-			wantQuery: "SELECT 1/*db_driver=database%2Fsql%3A*/;",
+			wantQuery: "SELECT 1/*db_driver='database%2Fsql%3A'*/;",
 		},
 		{
 			desc: "enable DBDriver and pass static tag driver name",
@@ -50,7 +50,7 @@ func TestWithComment_NoContext(t *testing.T) {
 				Tags:   core.StaticTags{DriverName: "postgres"},
 			},
 			query:     "SELECT 1;",
-			wantQuery: "SELECT 1/*db_driver=database%2Fsql%3Apostgres*/;",
+			wantQuery: "SELECT 1/*db_driver='database%2Fsql%3Apostgres'*/;",
 		},
 		{
 			desc: "enable DBDriver and pass all static tags",
@@ -59,7 +59,7 @@ func TestWithComment_NoContext(t *testing.T) {
 				Tags:   core.StaticTags{DriverName: "postgres", Application: "app-1"},
 			},
 			query:     "SELECT 1;",
-			wantQuery: "SELECT 1/*db_driver=database%2Fsql%3Apostgres*/;",
+			wantQuery: "SELECT 1/*db_driver='database%2Fsql%3Apostgres'*/;",
 		},
 		{
 			desc: "enable other tags and pass all static tags",
@@ -68,7 +68,7 @@ func TestWithComment_NoContext(t *testing.T) {
 				Tags:   core.StaticTags{DriverName: "postgres", Application: "app-1"},
 			},
 			query:     "SELECT 1;",
-			wantQuery: "SELECT 1/*application=app-1,db_driver=database%2Fsql%3Apostgres*/;",
+			wantQuery: "SELECT 1/*application='app-1',db_driver='database%2Fsql%3Apostgres'*/;",
 		},
 	}
 	for _, tc := range testCases {
@@ -122,7 +122,7 @@ func TestWithComment_WithContext(t *testing.T) {
 				},
 			),
 			query:     "SELECT 1;",
-			wantQuery: "SELECT 1/*application=app-1,db_driver=database%2Fsql%3Apostgres,framework=custom-golang,route=listData*/;",
+			wantQuery: "SELECT 1/*application='app-1',db_driver='database%2Fsql%3Apostgres',framework='custom-golang',route='listData'*/;",
 		},
 		{
 			desc: "only all options but context contains all tags",
@@ -147,7 +147,7 @@ func TestWithComment_WithContext(t *testing.T) {
 				},
 			),
 			query:     "SELECT 1;",
-			wantQuery: "SELECT 1/*action=any+action,application=app-1,db_driver=database%2Fsql%3Apostgres,framework=custom-golang,route=listData*/;",
+			wantQuery: "SELECT 1/*action='any+action',application='app-1',db_driver='database%2Fsql%3Apostgres',framework='custom-golang',route='listData'*/;",
 		},
 	}
 	for _, tc := range testCases {

--- a/go/database/sql/go.mod
+++ b/go/database/sql/go.mod
@@ -2,7 +2,7 @@ module github.com/google/sqlcommenter/go/database/sql
 
 go 1.19
 
-require github.com/google/sqlcommenter/go/core v0.1.0
+require github.com/google/sqlcommenter/go/core v0.1.2-beta
 
 require go.opentelemetry.io/otel v1.11.1 // indirect
 

--- a/go/database/sql/go.mod
+++ b/go/database/sql/go.mod
@@ -2,7 +2,7 @@ module github.com/google/sqlcommenter/go/database/sql
 
 go 1.19
 
-require github.com/google/sqlcommenter/go/core v0.1.2-beta
+require github.com/google/sqlcommenter/go/core v0.1.2
 
 require go.opentelemetry.io/otel v1.11.1 // indirect
 

--- a/go/database/sql/go.sum
+++ b/go/database/sql/go.sum
@@ -10,6 +10,8 @@ github.com/google/sqlcommenter/go/core v0.1.1 h1:DXaWbnQHJ00RqqGiyySPnaNHLqWuemt
 github.com/google/sqlcommenter/go/core v0.1.1/go.mod h1:GORu2htXRC4xtejBzOa4ct1L20pohP81DFNYKdCJI70=
 github.com/google/sqlcommenter/go/core v0.1.2-beta h1:fDg7rYUmqO1UJ3SqvDDEB7Wc0kDjpzgS81VGhcJTkoI=
 github.com/google/sqlcommenter/go/core v0.1.2-beta/go.mod h1:GORu2htXRC4xtejBzOa4ct1L20pohP81DFNYKdCJI70=
+github.com/google/sqlcommenter/go/core v0.1.2 h1:UM3jS7JROrPTsJxbLq68PRB34Iq8H3AZQDQUSV7sQWU=
+github.com/google/sqlcommenter/go/core v0.1.2/go.mod h1:GORu2htXRC4xtejBzOa4ct1L20pohP81DFNYKdCJI70=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 go.opentelemetry.io/otel v1.11.1 h1:4WLLAmcfkmDk2ukNXJyq3/kiz/3UzCaYq6PskJsaou4=

--- a/go/database/sql/go.sum
+++ b/go/database/sql/go.sum
@@ -6,6 +6,10 @@ github.com/google/sqlcommenter/go/core v0.0.5-beta h1:axqYR1zQCCdRBLnwr/j+ckllBS
 github.com/google/sqlcommenter/go/core v0.0.5-beta/go.mod h1:GORu2htXRC4xtejBzOa4ct1L20pohP81DFNYKdCJI70=
 github.com/google/sqlcommenter/go/core v0.1.0 h1:g5jL8HUk2Ko9mMPoCI4jP47dyJhpNyu6E8WmiEhh8OU=
 github.com/google/sqlcommenter/go/core v0.1.0/go.mod h1:GORu2htXRC4xtejBzOa4ct1L20pohP81DFNYKdCJI70=
+github.com/google/sqlcommenter/go/core v0.1.1 h1:DXaWbnQHJ00RqqGiyySPnaNHLqWuemtdP1DIheVXa/A=
+github.com/google/sqlcommenter/go/core v0.1.1/go.mod h1:GORu2htXRC4xtejBzOa4ct1L20pohP81DFNYKdCJI70=
+github.com/google/sqlcommenter/go/core v0.1.2-beta h1:fDg7rYUmqO1UJ3SqvDDEB7Wc0kDjpzgS81VGhcJTkoI=
+github.com/google/sqlcommenter/go/core v0.1.2-beta/go.mod h1:GORu2htXRC4xtejBzOa4ct1L20pohP81DFNYKdCJI70=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 go.opentelemetry.io/otel v1.11.1 h1:4WLLAmcfkmDk2ukNXJyq3/kiz/3UzCaYq6PskJsaou4=

--- a/go/database/sql/go.sum
+++ b/go/database/sql/go.sum
@@ -2,14 +2,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/sqlcommenter/go/core v0.0.5-beta h1:axqYR1zQCCdRBLnwr/j+ckllBSBJ7uaVdsnANuGzCUI=
-github.com/google/sqlcommenter/go/core v0.0.5-beta/go.mod h1:GORu2htXRC4xtejBzOa4ct1L20pohP81DFNYKdCJI70=
-github.com/google/sqlcommenter/go/core v0.1.0 h1:g5jL8HUk2Ko9mMPoCI4jP47dyJhpNyu6E8WmiEhh8OU=
-github.com/google/sqlcommenter/go/core v0.1.0/go.mod h1:GORu2htXRC4xtejBzOa4ct1L20pohP81DFNYKdCJI70=
-github.com/google/sqlcommenter/go/core v0.1.1 h1:DXaWbnQHJ00RqqGiyySPnaNHLqWuemtdP1DIheVXa/A=
-github.com/google/sqlcommenter/go/core v0.1.1/go.mod h1:GORu2htXRC4xtejBzOa4ct1L20pohP81DFNYKdCJI70=
-github.com/google/sqlcommenter/go/core v0.1.2-beta h1:fDg7rYUmqO1UJ3SqvDDEB7Wc0kDjpzgS81VGhcJTkoI=
-github.com/google/sqlcommenter/go/core v0.1.2-beta/go.mod h1:GORu2htXRC4xtejBzOa4ct1L20pohP81DFNYKdCJI70=
 github.com/google/sqlcommenter/go/core v0.1.2 h1:UM3jS7JROrPTsJxbLq68PRB34Iq8H3AZQDQUSV7sQWU=
 github.com/google/sqlcommenter/go/core v0.1.2/go.mod h1:GORu2htXRC4xtejBzOa4ct1L20pohP81DFNYKdCJI70=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
- Update SQLCommenter database/sql package to use core-1.2.
- Fixed unit tests to accommodate new version of core.