### PR TITLE
FIX: Undefined array key "controller" error and add docblocks

### DIFF
--- a/php/sqlcommenter-php/packages/sqlcommenter-laravel/src/Database/Connection.php
+++ b/php/sqlcommenter-php/packages/sqlcommenter-laravel/src/Database/Connection.php
@@ -37,6 +37,12 @@ class Connection extends BaseConnection
         );
     }
 
+    /**
+     * Append SQL comments to the underlying query.
+     *
+     * @param string $query
+     * @return string
+     */
     private function appendSqlComments(string $query): string
     {
         static $configurationKey = 'google_sqlcommenter.include';
@@ -52,7 +58,7 @@ class Connection extends BaseConnection
         if (config("{$configurationKey}.controller", true) && !empty($action['controller'])) {
             $comments['controller'] = explode("@", class_basename($action['controller']))[0];
         }
-        if (config("{$configurationKey}.action", true) && !empty($action and $action['controller'] && str_contains($action['controller'], '@'))) {
+        if (config("{$configurationKey}.action", true) && !empty($action) && !empty($action['controller']) && str_contains($action['controller'], '@')) {
             $comments['action'] = explode("@", class_basename($action['controller']))[1];
         }
         if (config("{$configurationKey}.route", true)) {

--- a/php/sqlcommenter-php/packages/sqlcommenter-laravel/src/Opentelemetry.php
+++ b/php/sqlcommenter-php/packages/sqlcommenter-laravel/src/Opentelemetry.php
@@ -21,6 +21,11 @@ use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
 
 class Opentelemetry
 {
+    /**
+     * Get the underlying Opentelemetry values.
+     *
+     * @return array
+     */
     public static function getOpentelemetryValues()
     {
         $carrier = [];

--- a/php/sqlcommenter-php/packages/sqlcommenter-laravel/src/Utils.php
+++ b/php/sqlcommenter-php/packages/sqlcommenter-laravel/src/Utils.php
@@ -19,6 +19,12 @@ namespace Google\GoogleSqlCommenterLaravel;
 
 class Utils
 {
+    /**
+     * Format query comments.
+     *
+     * @param array $comments
+     * @return string
+     */
     public static function formatComments(array $comments): string
     {
         if (empty($comments)) {
@@ -34,6 +40,12 @@ class Utils
         ) . "*/";
     }
 
+    /**
+     * Encode URL.
+     *
+     * @param string $input
+     * @return string
+     */
     private static function customUrlEncode(string $input): string
     {
         $encodedString = urlencode($input);


### PR DESCRIPTION
This pull request fixes an undefined array key error in sqlcommenter. The error occurred when trying to access the "controller" key of an array. This pull request resolves the issue by ensuring that the "controller" key is defined and initialized with a valid value.

Impact: `php/sqlcommenter-php/packages/sqlcommenter-laravel`