### PR TITLE
Remove unnecessary install_requires from setup.py

### DIFF
--- a/python/sqlcommenter-python/setup.py
+++ b/python/sqlcommenter-python/setup.py
@@ -34,7 +34,6 @@ setup(
     long_description_content_type='text/markdown',
     license='BSD',
     packages=find_packages(exclude=['tests']),
-    install_requires=['asgiref', 'fastapi'],
     extras_require={
         'django': ['django >= 1.11'],
         'flask': ['flask'],


### PR DESCRIPTION
Thinking in terms of a django install, there is no reason why `fastapi` and `asgiref` should not be an install requirement.