### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/laravel-integration-tests.yaml
+++ b/.github/workflows/laravel-integration-tests.yaml
@@ -35,7 +35,7 @@ jobs:
         working-directory: ./php/sqlcommenter-php/samples/sqlcommenter-laravel
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
+          echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v1
         with:
@@ -47,7 +47,7 @@ jobs:
       - name: Get yarn cache
         working-directory: ./php/sqlcommenter-php/samples/sqlcommenter-laravel
         id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v1
         with:

--- a/.github/workflows/laravel-unit-tests.yaml
+++ b/.github/workflows/laravel-unit-tests.yaml
@@ -26,7 +26,7 @@ jobs:
         working-directory: ./php/sqlcommenter-php/packages/sqlcommenter-laravel
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
+          echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v1
         with:
@@ -38,7 +38,7 @@ jobs:
       - name: Get yarn cache
         working-directory: ./php/sqlcommenter-php/packages/sqlcommenter-laravel
         id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v1
         with:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter