### PR TITLE
Update runners to ubuntu-24.04 from deprecated ubuntu-20.04 label

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -44,7 +44,7 @@ jobs:
         matrix:
           tox-environment: [ "lint" ]
       name: ${{ matrix.tox-environment }}
-      runs-on: ubuntu-20.04
+      runs-on: 'ubuntu-24.04'
       steps:
         - name: Checkout Contrib Repo @ SHA - ${{ github.sha }}
           uses: actions/checkout@v2


### PR DESCRIPTION
This is a LSC run by http://go/ghss to upgrade all depreacated ubuntu-20.04 runners to ubuntu-24.04.

On April 1, 2025, GitHub will stop supporting ubuntu-20.04 runners and workflows configured with this label will cease to run.  This PR is an attempt to save you work by doing the upgrade for you.

WARNING: We do not know if the updated label is compatiable with your workflow or not.

If you do not want to merge this PR, feel free to close it and deal with the problem yourselves.

More context and feedback: http://b/406537467
