### PR TITLE
Correct application tags for compatibility with CloudSQL

### DIFF
--- a/python/sqlcommenter-python/google/cloud/sqlcommenter/django/middleware.py
+++ b/python/sqlcommenter-python/google/cloud/sqlcommenter/django/middleware.py
@@ -67,15 +67,16 @@ class QueryWrapper:
 
         sql = add_sql_comment(
             sql,
+            # For supported tags, see: https://cloud.google.com/sql/docs/mysql/using-query-insights#using-sql-commenter
             # Information about the controller.
             controller=resolver_match.view_name if resolver_match and with_controller else None,
             # route is the pattern that matched a request with a controller i.e. the regex
             # See https://docs.djangoproject.com/en/stable/ref/urlresolvers/#django.urls.ResolverMatch.route
             # getattr() because the attribute doesn't exist in Django < 2.2.
             route=getattr(resolver_match, 'route', None) if resolver_match and with_route else None,
-            # app_name is the application namespace for the URL pattern that matches the URL.
+            # application is the application namespace for the URL pattern that matches the URL.
             # See https://docs.djangoproject.com/en/stable/ref/urlresolvers/#django.urls.ResolverMatch.app_name
-            app_name=(resolver_match.app_name or None) if resolver_match and with_app_name else None,
+            application=(resolver_match.app_name or None) if resolver_match and with_app_name else None,
             # Framework centric information.
             framework=('django:%s' % django_version) if with_framework else None,
             # Information about the database and driver.

--- a/python/sqlcommenter-python/google/cloud/sqlcommenter/fastapi.py
+++ b/python/sqlcommenter-python/google/cloud/sqlcommenter/fastapi.py
@@ -78,7 +78,7 @@ class SQLCommenterMiddleware:
 def _get_fastapi_info(fastapi_app: FastAPI, scope) -> dict:
     info = {
         "framework": 'fastapi:%s' % fastapi.__version__,
-        "app_name": fastapi_app.title,
+        "application": fastapi_app.title,
     }
 
     route = _get_fastapi_route(fastapi_app, scope)

--- a/python/sqlcommenter-python/tests/django/tests.py
+++ b/python/sqlcommenter-python/tests/django/tests.py
@@ -106,19 +106,19 @@ class Tests(TestCase):
     def test_app_path(self):
         with self.settings(SQLCOMMENTER_WITH_APP_NAME=True):
             query = self.get_query(path=reverse('app_urls:app-path'))
-            self.assertIn("/*app_name='app_urls'", query)
+            self.assertIn("/*application='app_urls'", query)
             self.assertIn("controller='app_urls%%3Aapp-path'", query)
             self.assertRoute('app-urls/app-path/', query)
 
     def test_app_name_disabled(self):
         query = self.get_query(path=reverse('app_urls:app-path'))
-        self.assertNotIn('app_name=', query)
+        self.assertNotIn('application=', query)
 
     def test_empty_app_name(self):
         """An empty app_name is omitted."""
         with self.settings(SQLCOMMENTER_WITH_APP_NAME=True):
             query = self.get_query()
-            self.assertNotIn("app_name=", query)
+            self.assertNotIn("application=", query)
 
     def test_db_driver(self):
         with self.settings(SQLCOMMENTER_WITH_DB_DRIVER=True):

--- a/python/sqlcommenter-python/tests/fastapi/tests.py
+++ b/python/sqlcommenter-python/tests/fastapi/tests.py
@@ -32,7 +32,7 @@ def client():
 
 def test_get_fastapi_info_in_request_context(client):
     expected = {
-        'app_name': 'SQLCommenter',
+        'application': 'SQLCommenter',
         'controller': 'fastapi_info',
         'framework': 'fastapi:%s' % fastapi.__version__,
         'route': '/fastapi-info',
@@ -43,7 +43,7 @@ def test_get_fastapi_info_in_request_context(client):
 
 def test_get_fastapi_info_in_404_error_context(client):
     expected = {
-        'app_name': 'SQLCommenter',
+        'application': 'SQLCommenter',
         'framework': 'fastapi:%s' % fastapi.__version__,
     }
     resp = client.get('/doesnt-exist')


### PR DESCRIPTION
This fixes a long outstanding bug where application is not properly tagged for some Python middleware. The tag was incorrectly set as `app_name` instead of `application` causing them not to be displayed in Google CloudSQL query insights.

https://cloud.google.com/sql/docs/mysql/using-query-insights#using-sql-commenter
